### PR TITLE
Fix incorrect window start position

### DIFF
--- a/emacs-live-py-mode/live-py-mode.el
+++ b/emacs-live-py-mode/live-py-mode.el
@@ -147,6 +147,7 @@ When the source buffer is narrowed the trace buffer remains
 aligned but will not hide the part after the narrowing."
   (let* ((output-window (get-buffer-window live-py-trace-name))
          (point-min-pos (point-min))
+         (scroll-margin 0)
          (point-min-line-nr (if (= 1 point-min-pos)
                                 1
                               ;; Compensate for narrowing.


### PR DESCRIPTION
If the value of `scroll-margin` is not 0, the live buffer won't align with source code buffer properly.

Wasn't sure whether to compensate for `scroll-margin` manually, so decided to set it to 0 locally for sake of simplicity.